### PR TITLE
Fix height issues with mobile nav and mobile presenter dialog on iOS

### DIFF
--- a/ui/components/nav.scss
+++ b/ui/components/nav.scss
@@ -233,7 +233,7 @@
     }
 
     &[data-expanded="true"] {
-      height: 100vh;
+      height: 100dvh;
       overflow-y: auto;
 
       .nav__menu {

--- a/ui/components/presenters.scss
+++ b/ui/components/presenters.scss
@@ -77,7 +77,7 @@
   max-width: 45.4275rem;
   padding: 4.4375rem 5.4375rem;
   padding-bottom: var(--space-3);
-  height: min(calc(100vh - var(--space-2)), 35rem);
+  height: min(calc(100dvh - var(--space-2)), 35rem);
   overflow: auto;
 
   .dialog-close {
@@ -209,8 +209,8 @@
     border: none;
     width: 100vw;
     max-width: 100vw;
-    height: 100vh;
-    max-height: 100vh;
+    height: 100dvh;
+    max-height: 100dvh;
     padding-inline: var(--space-3);
 
     .dialog-close {


### PR DESCRIPTION
**Problem**

On iOS Safari, the mobile navigation menu was being cut off at the bottom of the screen. This happens because iOS Safari has a bottom toolbar that dynamically appears and disappears as users scroll. When using 100vh (viewport height), CSS doesn't account for this dynamic toolbar, causing content to be hidden behind it.

Examples:

![image](https://github.com/user-attachments/assets/0b9fba35-53d6-4576-a491-ac38cd72eb1e)

![image](https://github.com/user-attachments/assets/c596df48-8c91-410b-85b4-f9cb0213bf6a)

**Solution**
- Replaced 100vh with 100dvh (dynamic viewport height) in mobile navigation and presenter dialogs
- 100dvh automatically adjusts to the actual visible viewport area, accounting for iOS Safari's dynamic UI elements